### PR TITLE
docs(README): add Button import to fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Wretched
 
 ```tsx
-import {Screen, Box, Flow, Text, interceptConsoleLog} from 'wretched'
+import {Screen, Box, Flow, Text, Button, interceptConsoleLog} from 'wretched'
 
 Screen.start(
   new Box({


### PR DESCRIPTION
resolves a `ReferenceError: Button is not defined` error I got \m/